### PR TITLE
ci: migrate release pipeline to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -2,64 +2,93 @@ name: Test Release Publish
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
-  test_release_publish:
-    name: Test, release and publish
+  test:
+    name: Run tests
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get yarn cache directory
+      - name: Get yarn cache
         id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ubuntu-latest-node-12.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ubuntu-latest-node-12.x-yarn-
-
+            ubuntu-latest-node-24.x-yarn-
       - uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: '24.x'
           registry-url: https://registry.npmjs.org/
-
       - name: Install
-        run: yarn install
-
+        run: yarn install --frozen-lockfile
       - name: Test
         run: yarn test --ci --bail
-
       - name: Build
         run: NODE_ENV=production yarn build
-
-      - uses: codecov/codecov-action@v4
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
 
-      - name: Setup environment variables
+  release_publish:
+    name: Release to Github and publish to NPM
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() && github.ref == 'refs/heads/main'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ubuntu-latest-node-24.x-yarn-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          registry-url: https://registry.npmjs.org/
+      - name: Install
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: NODE_ENV=production yarn build
+      - name: Setup env vars
         id: ownEnvVars
         run: |
-          echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-          COMMIT_LOG=$(git log $(git describe --tags --abbrev=0)..HEAD --date=iso-local --format='%cd %h %an - %s  ')
-          echo "COMMIT_LOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMIT_LOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
+          PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "COMMIT_LOG<<EOF" >> $GITHUB_ENV
+          git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --format='- %s (%an)' >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Check if version already released
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ env.PACKAGE_VERSION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - uses: ncipollo/release-action@v1
+        if: steps.check_tag.outputs.exists == 'false'
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.ownEnvVars.outputs.PACKAGE_VERSION }}
+          tag: ${{ env.PACKAGE_VERSION }}
           commit: main
-          body: ${{ steps.ownEnvVars.outputs.COMMIT_LOG }}
-
-      - name: Publish to npm
+          body: ${{ env.COMMIT_LOG }}
+      - name: npm publish
+        if: steps.check_tag.outputs.exists == 'false'
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Migrate the GitHub release pipeline to the "new way" used in `apple-signin-auth` / `react-apple-signin-auth`.

- Split the combined job into separate **`test`** and **`release_publish`** jobs (release runs only on `main`).
- Bump Node **22.x → 24.x**.
- Publish via **npm OIDC trusted publishing**: removed the `NPM_TOKEN` secret, added `id-token: write` and `environment: production`.
- Added a **tag-exists guard** (skips release/publish when the version tag already exists), `fetch-depth: 0`, and a first-release-safe changelog.
- Kept the build step and Codecov upload (bumped `codecov-action` v4 → v5).

## Note

Publishing only succeeds once the npm **trusted publisher** is configured for `micro-geoip-lite` (org/repo `a-tokyo/micro-geoip-lite-js`, workflow file `test-publish.yml`, environment `production`) — handled in a separate npm-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
