### PR TITLE
🐛 fix(npm): lowercase repo URL to match GitHub provenance (fixes 1.1.0 publish E422)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/A-Tokyo/micro-geoip-lite-js.git"
+    "url": "git+https://github.com/a-tokyo/micro-geoip-lite-js.git"
   },
   "main": "lib/index.js",
   "files": [
     "lib/"
   ],
-  "homepage": "https://github.com/A-Tokyo/micro-geoip-lite-js#readme",
+  "homepage": "https://github.com/a-tokyo/micro-geoip-lite-js#readme",
   "bugs": {
-    "url": "https://github.com/A-Tokyo/micro-geoip-lite-js/issues"
+    "url": "https://github.com/a-tokyo/micro-geoip-lite-js/issues"
   },
   "scripts": {
     "start": "babel-node src/index.js",


### PR DESCRIPTION
## What happened

The 1.1.0 publish blew up at npm's provenance check:

\`\`\`
422 ... Error verifying sigstore provenance bundle:
"repository.url" is "git+https://github.com/A-Tokyo/micro-geoip-lite-js.git",
expected to match "https://github.com/a-tokyo/micro-geoip-lite-js" from provenance
\`\`\`

Turns out GitHub Actions writes the provenance repo slug in lowercase (`a-tokyo/...`), but our `package.json` had it as `A-Tokyo/...` — and npm compares them case-sensitively. It only started failing now because we moved to OIDC trusted publishing in #24, which makes provenance mandatory.

## Fix

- Lowercased `repository.url` (and added the `git+` prefix, which also gets rid of npm's auto-correct warning)
- Lowercased `homepage` and `bugs.url` while I was in there, for consistency

## On the release

1.1.0 never actually made it to npm (latest there is still 1.0.1), so we're fine to reuse the version. I deleted the leftover 1.1.0 tag + GitHub release that got created before the publish failed — otherwise the workflow's "already released" guard would just skip the publish again. Once this merges, the workflow recreates the release and publishes 1.1.0 properly.

Heads up: the workflow still tags before it publishes, so a failed publish will leave a blocking tag again. Leaving that one for a follow-up.